### PR TITLE
Libsass integration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,5 +27,6 @@ module.exports = function(grunt) {
 
     grunt.loadNpmTasks('grunt-contrib-sass');
     grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-sass');
     grunt.registerTask('default', ['sass', 'watch']);
 };

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "2.0.4",
   "description": "The (un)official Sass Version of Skeleton (2.0.4): A Dead Simple, Responsive Boilerplate for Mobile-Friendly Development",
   "repository": {
-   "type": "git",
-   "url": "https://github.com/WhatsNewSaes/Skeleton-Sass"
+    "type": "git",
+    "url": "https://github.com/WhatsNewSaes/Skeleton-Sass"
   },
   "bugs": {
     "url": "https://github.com/WhatsNewSaes/Skeleton-Sass/issues"
@@ -22,6 +22,8 @@
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-contrib-sass": "~0.8.1"
+    "grunt-contrib-sass": "~0.8.1",
+    "node-sass": "~3.4.2",
+    "grunt-sass": "~1.1.0"
   }
 }


### PR DESCRIPTION
https://benfrain.com/lightning-fast-sass-compiling-with-libsass-node-sass-and-grunt-sass/
ruby's sass compilation process were predominantly slower
http://sass-lang.com/libsass - a C/C++ port of the sass engine is known to compile sass scripts heaps faster

Had a look @ https://www.npmjs.com/package/grunt-libsass, but that package seems to be inactive anymore

this PR has changes to make the Skeleton-Sass to integrate libsass compilation by adding:
 - node-sass - nodejs's wrapper to libsass
   https://github.com/sass/node-sass

 - and the grunt wrapper - grunt-sass
   https://github.com/sindresorhus/grunt-sass